### PR TITLE
fix(auth): validar token contra el backend al montar AuthContext

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import { loginUser, registerUser } from '../services/api';
+import { loginUser, registerUser, getPerfil } from '../services/api';
 import { useToast } from './ToastContext';
 
 const AuthContext = createContext(null);
@@ -9,18 +9,21 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const { showToast } = useToast();
 
+  // Valida el token contra el backend al montar
   useEffect(() => {
     const token = localStorage.getItem('ga_token');
-    const stored = localStorage.getItem('ga_user');
-    if (token && stored) {
-      try {
-        setUser(JSON.parse(stored));
-      } catch {
+    if (!token) { setLoading(false); return; }
+
+    getPerfil()
+      .then(({ data }) => {
+        setUser(data.data.user);
+        localStorage.setItem('ga_user', JSON.stringify(data.data.user));
+      })
+      .catch(() => {
         localStorage.removeItem('ga_token');
         localStorage.removeItem('ga_user');
-      }
-    }
-    setLoading(false);
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   const login = async (email, password) => {


### PR DESCRIPTION
En lugar de restaurar la sesión solo desde localStorage, se llama a getPerfil() al inicializar el contexto para verificar que el token almacenado sigue siendo válido en el backend.

- Si el token es válido, se actualiza el estado del usuario con los datos frescos devueltos por la API.
- Si el token expiró o es inválido, se limpia localStorage y se cierra la sesión automáticamente.

Esto evita que usuarios con tokens vencidos permanezcan autenticados en el cliente tras recargar la página.